### PR TITLE
increase unit tests coverage

### DIFF
--- a/package/tests/test_cp/test_azure/test_domain/test_services/test_parsers/test_azure_model_parser.py
+++ b/package/tests/test_cp/test_azure/test_domain/test_services/test_parsers/test_azure_model_parser.py
@@ -1,0 +1,146 @@
+from unittest import TestCase
+
+import mock
+
+from cloudshell.cp.azure.domain.services.parsers.azure_model_parser import AzureModelsParser
+
+
+class TestAzureModelsParser(TestCase):
+    def setUp(self):
+        self.tested_class = AzureModelsParser
+
+    @mock.patch("cloudshell.cp.azure.domain.services.parsers.azure_model_parser.jsonpickle")
+    @mock.patch("cloudshell.cp.azure.domain.services.parsers.azure_model_parser.DeployDataHolder")
+    def test_convert_app_resource_to_deployed_app(self, deploy_data_holder_class, jsonpickle):
+        """Check that method will convert string to DeployDataHolder model"""
+        resource = mock.MagicMock()
+        decoded_data = mock.MagicMock()
+        deployed_app = mock.MagicMock()
+        jsonpickle.decode.return_value = decoded_data
+        deploy_data_holder_class.return_value = deployed_app
+
+        # Act
+        result = self.tested_class.convert_app_resource_to_deployed_app(resource)
+
+        # Verify
+        deploy_data_holder_class.assert_called_once_with(decoded_data)
+        self.assertEqual(result, deployed_app)
+
+    @mock.patch("cloudshell.cp.azure.domain.services.parsers.azure_model_parser.DeployAzureVMResourceModel")
+    @mock.patch("cloudshell.cp.azure.domain.services.parsers.azure_model_parser.jsonpickle")
+    @mock.patch("cloudshell.cp.azure.domain.services.parsers.azure_model_parser.DeployDataHolder")
+    def test_convert_to_deployment_resource_model(self, deploy_data_holder_class, jsonpickle,
+                                                  deploy_azure_vm_model_class):
+        """Check that method returns DeployAzureVMResourceModel instance with attrs from DeployDataHolder"""
+        data_holder = mock.MagicMock()
+        deploy_azure_vm_model = mock.MagicMock()
+        deploy_data_holder_class.return_value = data_holder
+        deployment_request = mock.MagicMock()
+        deploy_azure_vm_model_class.return_value = deploy_azure_vm_model
+
+        # Act
+        result = self.tested_class.convert_to_deployment_resource_model(deployment_request)
+
+        # Verify
+        self.assertIs(result, deploy_azure_vm_model)
+        self.assertEqual(result.add_public_ip, data_holder.ami_params.add_public_ip)
+        self.assertEqual(result.autoload, data_holder.ami_params.autoload)
+        self.assertEqual(result.cloud_provider, data_holder.ami_params.cloud_provider)
+        self.assertEqual(result.disk_type, data_holder.ami_params.disk_type)
+        self.assertEqual(result.group_name, data_holder.ami_params.group_name)
+        self.assertEqual(result.image_offer, data_holder.ami_params.image_offer)
+        self.assertEqual(result.image_publisher, data_holder.ami_params.image_publisher)
+        self.assertEqual(result.image_sku, data_holder.ami_params.image_sku)
+        self.assertEqual(result.inbound_ports, data_holder.ami_params.inbound_ports)
+        self.assertEqual(result.instance_type, data_holder.ami_params.instance_type)
+        self.assertEqual(result.outbound_ports, data_holder.ami_params.outbound_ports)
+        self.assertEqual(result.public_ip_type, data_holder.ami_params.public_ip_type)
+        self.assertEqual(result.vm_name, data_holder.ami_params.vm_name)
+        self.assertEqual(result.wait_for_ip, data_holder.ami_params.wait_for_ip)
+        self.assertEqual(result.app_name, data_holder.app_name)
+
+    @mock.patch("cloudshell.cp.azure.domain.services.parsers.azure_model_parser.AzureCloudProviderResourceModel")
+    def test_convert_to_cloud_provider_resource_model(self, azure_cp_model_class):
+        """Check that method returns AzureCloudProviderResourceModel instance with attrs from context"""
+        azure_cp_model = mock.MagicMock()
+        azure_cp_model_class.return_value = azure_cp_model
+        test_resource = mock.Mock()
+        test_resource.attributes = {}
+        test_resource.attributes["Azure Client ID"] = test_azure_client_id = mock.MagicMock()
+        test_resource.attributes["Azure Mgmt Network ID"] = test_azure_mgmt_id = mock.MagicMock()
+        test_resource.attributes["Azure Mgmt NSG ID"] = test_azure_mgmt_nsg_id = mock.MagicMock()
+        test_resource.attributes["Azure Secret"] = test_azure_secret = mock.MagicMock()
+        test_resource.attributes["Azure Subscription ID"] = test_azure_subscription_id = mock.MagicMock()
+        test_resource.attributes["Azure Tenant"] = test_azure_tenant = mock.MagicMock()
+        test_resource.attributes["Instance Type"] = test_instance_type = mock.MagicMock()
+        test_resource.attributes["Keypairs Location"] = test_keypairts_location = mock.MagicMock()
+        test_resource.attributes["Networks In Use"] = test_networks_in_use = mock.MagicMock()
+        test_resource.attributes["Region"] = test_region = mock.MagicMock()
+        test_resource.attributes["Storage Type"] = test_storage_type = mock.MagicMock()
+        test_resource.attributes["Management Group Name"] = test_mgmt_group_name = mock.MagicMock()
+
+        # Act
+        result = self.tested_class.convert_to_cloud_provider_resource_model(test_resource)
+
+        # Verify
+        self.assertIs(result, azure_cp_model)
+        self.assertEqual(result.azure_client_id, test_azure_client_id)
+        self.assertEqual(result.azure_mgmt_network_d, test_azure_mgmt_id)
+        self.assertEqual(result.azure_mgmt_nsg_id, test_azure_mgmt_nsg_id)
+        self.assertEqual(result.azure_secret, test_azure_secret)
+        self.assertEqual(result.azure_subscription_id, test_azure_subscription_id)
+        self.assertEqual(result.azure_tenant, test_azure_tenant)
+        self.assertEqual(result.instance_type, test_instance_type)
+        self.assertEqual(result.keypairs_location, test_keypairts_location)
+        self.assertEqual(result.networks_in_use, test_networks_in_use)
+        self.assertEqual(result.region, test_region)
+        self.assertEqual(result.storage_type, test_storage_type)
+        self.assertEqual(result.management_group_name, test_mgmt_group_name)
+
+    @mock.patch("cloudshell.cp.azure.domain.services.parsers.azure_model_parser.ReservationModel")
+    def test_convert_to_reservation_model(self, reservation_model_class):
+        """Check that method will return ReservationModel instance from given context"""
+        reservation_model = mock.MagicMock()
+        reservation_model_class.return_value = reservation_model
+        reservation_context = mock.MagicMock()
+
+        # Act
+        result = self.tested_class.convert_to_reservation_model(reservation_context)
+
+        # Verify
+        self.assertIs(result, reservation_model)
+        reservation_model_class.assert_called_once_with(reservation_context)
+
+    def test_get_public_ip_from_connected_resource_details(self):
+        """Check that method will return Public IP attr from the context"""
+        public_ip = mock.MagicMock()
+        resource_context = mock.MagicMock(remote_endpoints=[
+            mock.MagicMock(attributes={"Public IP": public_ip})])
+
+        # Act
+        result = self.tested_class.get_public_ip_from_connected_resource_details(resource_context)
+
+        # Verify
+        self.assertIs(result, public_ip)
+
+    def test_get_private_ip_from_connected_resource_details(self):
+        """Check that method will return Private IP attr from the context"""
+        private_ip = mock.MagicMock()
+        resource_context = mock.MagicMock(remote_endpoints=[mock.MagicMock(address=private_ip)])
+
+        # Act
+        result = self.tested_class.get_private_ip_from_connected_resource_details(resource_context)
+
+        # Verify
+        self.assertIs(result, private_ip)
+
+    def test_get_connected_resource_fullname(self):
+        """Check that method will return fullname from the resource context"""
+        fullname = mock.MagicMock()
+        resource_context = mock.MagicMock(remote_endpoints=[mock.MagicMock(fullname=fullname)])
+
+        # Act
+        result = self.tested_class.get_connected_resource_fullname(resource_context)
+
+        # Verify
+        self.assertIs(result, fullname)

--- a/package/tests/test_cp/test_azure/test_domain/test_services/test_parsers/test_command_result_parser.py
+++ b/package/tests/test_cp/test_azure/test_domain/test_services/test_parsers/test_command_result_parser.py
@@ -1,0 +1,23 @@
+from unittest import TestCase
+
+import mock
+
+from cloudshell.cp.azure.domain.services.parsers.command_result_parser import CommandResultsParser
+
+
+class TestCommandResultsParser(TestCase):
+    def setUp(self):
+        self.command_result_parser = CommandResultsParser()
+
+    @mock.patch("cloudshell.cp.azure.domain.services.parsers.command_result_parser.jsonpickle")
+    def test_set_command_result(self, jsonpickle):
+        """Check that method will convert result to string"""
+        test_result = mock.MagicMock()
+        unpicklable = mock.MagicMock()
+
+        # Act
+        result = self.command_result_parser.set_command_result(result=test_result, unpicklable=unpicklable)
+
+        # Verify
+        self.assertIsInstance(result, str)
+        jsonpickle.encode.assert_called_once_with(test_result, unpicklable=unpicklable)

--- a/package/tests/test_cp/test_azure/test_domain/test_vm_management/test_operations/test_refresh_ip_operation.py
+++ b/package/tests/test_cp/test_azure/test_domain/test_vm_management/test_operations/test_refresh_ip_operation.py
@@ -1,0 +1,90 @@
+from unittest import TestCase
+
+from msrestazure.azure_exceptions import CloudError
+import mock
+
+from cloudshell.cp.azure.domain.vm_management.operations.refresh_ip_operation import RefreshIPOperation
+
+
+class TestRefreshIPOperation(TestCase):
+    def setUp(self):
+        self.logger = mock.MagicMock()
+        self.cloudshell_session = mock.MagicMock()
+        self.compute_client = mock.MagicMock()
+        self.network_client = mock.MagicMock()
+        self.resource_group_name = "test_resource_group_name"
+        self.resource_fullname = "test_resource_fullname"
+        self.vm_name = "test_vm_name"
+        self.private_ip_on_resource = "10.0.0.1"
+        self.public_ip_on_resource = "172.29.128.255"
+
+        self.refresh_ip_operation = RefreshIPOperation(logger=self.logger)
+
+    def test_refresh_ip(self):
+        """Check that method uses network client to get public IP value and updates it on CloudShell"""
+        self.network_client.public_ip_addresses.get.return_value = public_ip_from_azure = mock.MagicMock()
+        self.network_client.network_interfaces.get.return_value = nic = mock.MagicMock()
+
+        # Act
+        self.refresh_ip_operation.refresh_ip(
+            cloudshell_session=self.cloudshell_session,
+            compute_client=self.compute_client,
+            network_client=self.network_client,
+            resource_group_name=self.resource_group_name,
+            vm_name=self.vm_name,
+            private_ip_on_resource=self.private_ip_on_resource,
+            public_ip_on_resource=self.public_ip_on_resource,
+            resource_fullname=self.resource_fullname)
+
+        # Verify
+        self.network_client.public_ip_addresses.get.assert_called_once_with(self.resource_group_name, self.vm_name)
+        self.cloudshell_session.SetAttributeValue.assert_called_once_with(self.resource_fullname, "Public IP",
+                                                                          public_ip_from_azure.ip_address)
+
+        self.cloudshell_session.UpdateResourceAddress.assert_called_once_with(
+            self.resource_fullname, nic.ip_configurations[0].private_ip_address)
+
+    def test_refresh_ip_no_public_ip_on_azure(self):
+        """Check that method handles Azure CloudError exception (no Public IP on Azure)"""
+        self.network_client.network_interfaces.get.return_value = nic = mock.MagicMock()
+        self.network_client.public_ip_addresses.get.side_effect = CloudError(mock.MagicMock())
+
+        # Act
+        self.refresh_ip_operation.refresh_ip(
+            cloudshell_session=self.cloudshell_session,
+            compute_client=self.compute_client,
+            network_client=self.network_client,
+            resource_group_name=self.resource_group_name,
+            vm_name=self.vm_name,
+            private_ip_on_resource=self.private_ip_on_resource,
+            public_ip_on_resource=self.public_ip_on_resource,
+            resource_fullname=self.resource_fullname)
+
+        # Verify
+        self.network_client.public_ip_addresses.get.assert_called_once_with(self.resource_group_name, self.vm_name)
+        self.cloudshell_session.SetAttributeValue.assert_called_once_with(self.resource_fullname, "Public IP", "")
+
+        self.cloudshell_session.UpdateResourceAddress.assert_called_once_with(
+            self.resource_fullname, nic.ip_configurations[0].private_ip_address)
+
+    def test_refresh_ip_does_not_update_ips(self):
+        """Check that method will not update private/public IPs on the CloudShell if they are same as on Azure"""
+        self.network_client.public_ip_addresses.get.return_value = mock.MagicMock(ip_address=self.public_ip_on_resource)
+        self.network_client.network_interfaces.get.return_value = mock.MagicMock(
+            ip_configurations=[mock.MagicMock(private_ip_address=self.private_ip_on_resource)])
+
+        # Act
+        self.refresh_ip_operation.refresh_ip(
+            cloudshell_session=self.cloudshell_session,
+            compute_client=self.compute_client,
+            network_client=self.network_client,
+            resource_group_name=self.resource_group_name,
+            vm_name=self.vm_name,
+            private_ip_on_resource=self.private_ip_on_resource,
+            public_ip_on_resource=self.public_ip_on_resource,
+            resource_fullname=self.resource_fullname)
+
+        # Verify
+        self.network_client.public_ip_addresses.get.assert_called_once_with(self.resource_group_name, self.vm_name)
+        self.cloudshell_session.SetAttributeValue.assert_not_called()
+        self.cloudshell_session.UpdateResourceAddress.assert_not_called()


### PR DESCRIPTION
Add coverage for the next modules:
- package/cloudshell/cp/azure/domain/services/parsers/azure_model_parser.py
- package/cloudshell/cp/azure/domain/services/parsers/command_result_parser.py
- package/cloudshell/cp/azure/domain/vm_management/operations/refresh_ip_operation.py

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/azure-shell/109)
<!-- Reviewable:end -->
