### PR TITLE
Bug 211 fix. Not all security rules are being deleted when deleting a…

### DIFF
--- a/package/cloudshell/cp/azure/domain/services/security_group.py
+++ b/package/cloudshell/cp/azure/domain/services/security_group.py
@@ -175,10 +175,11 @@ class SecurityGroupService(object):
                     destination_addr=destination_addr,
                     priority=next(priority_generator))
 
-    def delete_security_rules(self, network_client, resource_group_name, vm_name):
+    def delete_security_rules(self, network_client, resource_group_name, vm_name, logger):
         """
         removes NSG inbound rules for virtual machine (based on private ip address)
 
+        :param logger:
         :param vm_name:
         :param network_client: azure.mgmt.network.NetworkManagementClient instance
         :param resource_group_name: resource group name (reservation id)
@@ -203,8 +204,11 @@ class SecurityGroupService(object):
             return
 
         for vm_rule in vm_rules:
-            network_client.security_rules.delete(
+            logger.info("Deleting security group rule '{}'.".format(vm_rule.name))
+            result = network_client.security_rules.delete(
                 resource_group_name=resource_group_name,
                 network_security_group_name=security_group.name,
                 security_rule_name=vm_rule.name
             )
+            result.wait()
+            logger.info("Security group rule '{}' deleted.".format(vm_rule.name))

--- a/package/cloudshell/cp/azure/domain/vm_management/operations/delete_operation.py
+++ b/package/cloudshell/cp/azure/domain/vm_management/operations/delete_operation.py
@@ -130,7 +130,8 @@ class DeleteAzureVMOperation(object):
             logger.info("Deleting security group rules...")
             self.security_group_service.delete_security_rules(network_client=network_client,
                                                               resource_group_name=group_name,
-                                                              vm_name=vm_name)
+                                                              vm_name=vm_name,
+                                                              logger=logger)
 
             logger.info("Deleting VM {}...".format(vm_name))
             self.vm_service.delete_vm(compute_management_client=compute_client,

--- a/package/tests/test_services/test_services.py
+++ b/package/tests/test_services/test_services.py
@@ -1238,7 +1238,7 @@ class TestSecurityGroupService(TestCase):
         self.network_service.get_private_ip = Mock(return_value=private_ip_address)
 
         # Act
-        self.security_group_service.delete_security_rules(network_client, resource_group_name, vm_name)
+        self.security_group_service.delete_security_rules(network_client, resource_group_name, vm_name, Mock())
 
         # Verify
         network_client.security_rules.delete.assert_called_once_with(


### PR DESCRIPTION
…n vm that have more than one inbound security rule.

Before it the concurrency issue: {"error":{"code":"AuthenticationFailed","message":"Authentication failed. The 'Authorization' header is missing."}}

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/azure-shell/228)
<!-- Reviewable:end -->
