### PR TITLE
bug 260 region attribute on the cloud provider accepts only lower case

### DIFF
--- a/package/cloudshell/cp/azure/domain/services/parsers/azure_model_parser.py
+++ b/package/cloudshell/cp/azure/domain/services/parsers/azure_model_parser.py
@@ -83,7 +83,7 @@ class AzureModelsParser(object):
         azure_resource_model.azure_tenant = resource_context['Azure Tenant']
         azure_resource_model.instance_type = resource_context['Instance Type']
         azure_resource_model.networks_in_use = resource_context['Networks In Use']
-        azure_resource_model.region = resource_context['Region']
+        azure_resource_model.region = resource_context['Region'].replace(" ", "").lower()
         azure_resource_model.management_group_name = resource_context['Management Group Name']
 
         encrypted_azure_secret = resource_context['Azure Secret']

--- a/package/tests/test_cp/test_azure/test_domain/test_services/test_parsers/test_azure_model_parser.py
+++ b/package/tests/test_cp/test_azure/test_domain/test_services/test_parsers/test_azure_model_parser.py
@@ -112,7 +112,7 @@ class TestAzureModelsParser(TestCase):
         test_resource.attributes["Azure Tenant"] = test_azure_tenant = mock.MagicMock()
         test_resource.attributes["Instance Type"] = test_instance_type = mock.MagicMock()
         test_resource.attributes["Networks In Use"] = test_networks_in_use = mock.MagicMock()
-        test_resource.attributes["Region"] = test_region = mock.MagicMock()
+        test_resource.attributes["Region"] = "East Canada"
         test_resource.attributes["Management Group Name"] = test_mgmt_group_name = mock.MagicMock()
         cloudshell_session = mock.MagicMock()
         decrypted_azure_secret = mock.MagicMock()
@@ -129,7 +129,7 @@ class TestAzureModelsParser(TestCase):
         self.assertEqual(result.azure_tenant, test_azure_tenant)
         self.assertEqual(result.instance_type, test_instance_type)
         self.assertEqual(result.networks_in_use, test_networks_in_use)
-        self.assertEqual(result.region, test_region)
+        self.assertEqual(result.region, "eastcanada")
         self.assertEqual(result.management_group_name, test_mgmt_group_name)
         self.assertEqual(result.azure_secret, decrypted_azure_secret.Value)
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/azure-shell/279)
<!-- Reviewable:end -->
