### PR TITLE
fix bug 263 Teardown not always deletes the subnet of the reservation

### DIFF
--- a/package/cloudshell/cp/azure/domain/services/network_service.py
+++ b/package/cloudshell/cp/azure/domain/services/network_service.py
@@ -325,11 +325,27 @@ class NetworkService(object):
         """
 
         :param azure.mgmt.network.network_management_client.NetworkManagementClient network_client:
-        :param group_name:
-        :param ip_name:
+        :param group_name: (str) resource group name (reservation id)
+        :param ip_name: (str) name for Azure Public IP resource
         :return:
         """
         result = network_client.public_ip_addresses.delete(group_name, ip_name)
+        result.wait()
+
+    @retry(stop_max_attempt_number=5, wait_fixed=2000, retry_on_exception=retry_if_connection_error)
+    def delete_subnet(self, network_client, group_name, vnet_name, subnet_name):
+        """
+
+        :param network_client: azure.mgmt.network.network_management_client.NetworkManagementClient instance
+        :param group_name: (str) resource group name (reservation id)
+        :param vnet_name: (str) virtual network name
+        :param subnet_name: (str) subnet name
+        :return:
+        """
+        result = network_client.subnets.delete(resource_group_name=group_name,
+                                               virtual_network_name=vnet_name,
+                                               subnet_name=subnet_name)
+        result.wait()
 
     @retry(stop_max_attempt_number=5, wait_fixed=2000, retry_on_exception=retry_if_connection_error)
     def get_virtual_networks(self, network_client, group_name):

--- a/package/cloudshell/cp/azure/domain/vm_management/operations/delete_operation.py
+++ b/package/cloudshell/cp/azure/domain/vm_management/operations/delete_operation.py
@@ -119,8 +119,11 @@ class DeleteAzureVMOperation(object):
 
         with self.subnet_locker:
             logger.info("Deleting subnet {}".format(subnet.name))
-            network_client.subnets.delete(cloud_provider_model.management_group_name, sandbox_virtual_network.name,
-                                          subnet.name)
+            self.network_service.delete_subnet(network_client=network_client,
+                                               group_name=cloud_provider_model.management_group_name,
+                                               vnet_name=sandbox_virtual_network.name,
+                                               subnet_name=subnet.name)
+
             logger.info("Deleted subnet {}".format(subnet.name))
 
     def _delete_security_rules(self, network_client, group_name, vm_name, logger):


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/azure-shell/280)
<!-- Reviewable:end -->
