### PR TITLE
fixed call to "_rollback_deployed_resources” during deploy

### DIFF
--- a/package/cloudshell/cp/azure/domain/vm_management/operations/deploy_operation.py
+++ b/package/cloudshell/cp/azure/domain/vm_management/operations/deploy_operation.py
@@ -347,7 +347,6 @@ class DeployAzureVMOperation(object):
                                               interface_name=interface_name,
                                               vm_name=vm_name,
                                               ip_name=ip_name,
-                                              cancellation_context=cancellation_context,
                                               logger=logger)
 
             raise
@@ -545,7 +544,6 @@ class DeployAzureVMOperation(object):
                                               interface_name=interface_name,
                                               vm_name=vm_name,
                                               ip_name=ip_name,
-                                              cancellation_context=cancellation_context,
                                               logger=logger)
             raise
 

--- a/package/tests/test_cp/test_azure/test_domain/test_vm_management/test_operations/test_deploy_operation.py
+++ b/package/tests/test_cp/test_azure/test_domain/test_vm_management/test_operations/test_deploy_operation.py
@@ -255,7 +255,6 @@ class TestDeployAzureVMOperation(TestCase):
             ip_name=test_name,
             network_client=network_client,
             vm_name=test_name,
-            cancellation_context=cancellation_context,
             logger=logger)
 
     def test_deploy_operation_virtual_networks_validation(self):


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/azure-shell/342)
<!-- Reviewable:end -->
