### PR TITLE
Execution server selector attribute is missing from the discovery for…

### DIFF
--- a/drivers/azure_shellPackage/Configuration/shellconfig.xml
+++ b/drivers/azure_shellPackage/Configuration/shellconfig.xml
@@ -19,6 +19,7 @@
                 <Attribute Value="" Name="Azure Client ID"/>
                 <Attribute Value="" Name="Management Group Name"/>
                 <Attribute Value="" Name="Additional Mgmt Networks"/>
+                <Attribute Value="" Name="Execution Server Selector"/>
             </Attributes>
         </ResourceTemplate>
     </ResourceTemplates>

--- a/package/tests/test_cp/test_azure/test_domain/test_services/test_parsers/test_azure_model_parser.py
+++ b/package/tests/test_cp/test_azure/test_domain/test_services/test_parsers/test_azure_model_parser.py
@@ -178,6 +178,7 @@ class TestAzureModelsParser(TestCase):
         test_resource.attributes["Networks In Use"] = "network1,  network2 "
         test_resource.attributes["Region"] = "East Canada"
         test_resource.attributes["Management Group Name"] = test_mgmt_group_name = mock.MagicMock()
+        test_resource.attributes["Execution Server Selector"] = ""
         cloudshell_session = mock.MagicMock()
         decrypted_azure_secret = mock.MagicMock()
         cloudshell_session.DecryptPassword.return_value = decrypted_azure_secret


### PR DESCRIPTION
Execution server selector attribute is missing from the discovery form #397

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/azure-shell/399)
<!-- Reviewable:end -->
