### PR TITLE
fix bug 380 in autoload discovery, when leaving the region attribute …

### DIFF
--- a/package/cloudshell/cp/azure/domain/vm_management/operations/autoload_operation.py
+++ b/package/cloudshell/cp/azure/domain/vm_management/operations/autoload_operation.py
@@ -18,6 +18,15 @@ class AutoloadOperation(object):
         self.vm_service = vm_service
         self.network_service = network_service
 
+    def _validate_region(self, region):
+        """Verify Azure region
+
+        :param str region: Azure region
+        :return:
+        """
+        if not region:
+            raise AutoloadException("Region attribute can not be empty")
+
     def _validate_api_credentials(self, cloud_provider_model, logger):
         """Verify Azure API Credentials and return AzureClientsManager instance
 
@@ -141,6 +150,8 @@ class AutoloadOperation(object):
         logger.info("Starting Autoload Operation...")
 
         azure_clients = self._validate_api_credentials(cloud_provider_model=cloud_provider_model, logger=logger)
+
+        self._validate_region(cloud_provider_model.region)
 
         self._register_azure_providers(resource_client=azure_clients.resource_client, logger=logger)
 

--- a/package/tests/test_cp/test_azure/test_domain/test_vm_management/test_operations/test_autoload_operation.py
+++ b/package/tests/test_cp/test_azure/test_domain/test_vm_management/test_operations/test_autoload_operation.py
@@ -56,6 +56,15 @@ class TestAutoloadOperation(TestCase):
         # Verify
         self.assertEqual(ex.exception.message, "Failed to connect to Azure API, please check the log for more details")
 
+    def test_validate_region(self):
+        """Check that method will raise AutoloadException if region is empty"""
+        # Act
+        with self.assertRaises(AutoloadException) as ex:
+            self.autoload_operation._validate_region(region="")
+
+        # Verify
+        self.assertEqual(ex.exception.message, "Region attribute can not be empty")
+
     def test_validate_mgmt_resource_group_not_found(self):
         """Check that method will raise AutoloadException if management resource group doesn't exist on Azure"""
         resource_client = mock.MagicMock()


### PR DESCRIPTION
…empty there is no relevant error

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/azure-shell/400)
<!-- Reviewable:end -->
