### PR TITLE
removed calls  to SetResourceLiveStatus when power commands

### DIFF
--- a/package/cloudshell/cp/azure/azure_shell.py
+++ b/package/cloudshell/cp/azure/azure_shell.py
@@ -380,8 +380,6 @@ class AzureShell(object):
 
                 logger.info('Azure VM {} was successfully powered off'.format(vm_name))
 
-                with CloudShellSessionContext(command_context) as cloudshell_session:
-                    cloudshell_session.SetResourceLiveStatus(resource.fullname, "Offline", "Powered Off")
 
     def refresh_ip(self, command_context):
         """Refresh private and public IPs on the Cloudshell resource

--- a/package/cloudshell/cp/azure/domain/vm_management/operations/power_operation.py
+++ b/package/cloudshell/cp/azure/domain/vm_management/operations/power_operation.py
@@ -33,7 +33,6 @@ class PowerAzureVMOperation(object):
 
         self.vm_service.start_vm(compute_client, resource_group_name, vm_name)
 
-        cloudshell_session.SetResourceLiveStatus(resource_full_name, "Online", "Active")
 
     def power_off(self, compute_client, resource_group_name, vm_name):
         """Power off Azure VM instance

--- a/package/tests/test_cp/test_azure/test_azure_shell.py
+++ b/package/tests/test_cp/test_azure/test_azure_shell.py
@@ -358,9 +358,6 @@ class TestAzureShell(TestCase):
             resource_group_name=self.group_name,
             vm_name=self.vm_name)
 
-        cloudshell_session.SetResourceLiveStatus.assert_called_once_with(
-            command_context.remote_endpoints[0].fullname, "Offline", "Powered Off")
-
     @mock.patch("cloudshell.cp.azure.azure_shell.CloudShellSessionContext")
     @mock.patch("cloudshell.cp.azure.azure_shell.AzureClientsManager")
     @mock.patch("cloudshell.cp.azure.azure_shell.LoggingSessionContext")


### PR DESCRIPTION
power commands calls to SetResourceLiveStatus were moved to server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/azure-shell/501)
<!-- Reviewable:end -->
