### PR TITLE
Feature/alex 167200 vm details multiple nics

### DIFF
--- a/package/cloudshell/cp/azure/domain/common/vm_details_provider.py
+++ b/package/cloudshell/cp/azure/domain/common/vm_details_provider.py
@@ -66,8 +66,7 @@ class VmDetailsProvider(object):
 
         for network_interface in instance.network_profile.network_interfaces:
 
-            # get the nic name from the nic id
-            nic_name = network_interface.id.split('/')[-1]
+            nic_name = self.resource_id_parser.get_name_from_resource_id(network_interface.id)
 
             nic = network_client.network_interfaces.get(group_name, nic_name)
             ip_configuration = nic.ip_configurations[0]

--- a/package/cloudshell/cp/azure/domain/vm_management/operations/refresh_ip_operation.py
+++ b/package/cloudshell/cp/azure/domain/vm_management/operations/refresh_ip_operation.py
@@ -33,7 +33,9 @@ class RefreshIPOperation(object):
             group_name=resource_group_name,
             vm_name=vm_name)
 
-        nic_reference = vm.network_profile.network_interfaces[0]
+        # find the primary nic
+        primary_nic_ref = next(iter(filter(lambda x: x.primary, vm.network_profile.network_interfaces)), None)
+        nic_reference = primary_nic_ref if primary_nic_ref else vm.network_profile.network_interfaces[0]
         nic_name = self.resource_id_parser.get_name_from_resource_id(nic_reference.id)
         logger.info("Retrieving NIC {} for VM {}".format(nic_name, vm_name))
         nic = network_client.network_interfaces.get(resource_group_name, nic_name)

--- a/package/tests/test_cp/test_azure/test_common/test_vm_details_provider.py
+++ b/package/tests/test_cp/test_azure/test_common/test_vm_details_provider.py
@@ -23,7 +23,8 @@ class TestVmDetailsProvider(TestCase):
         instance.storage_profile.os_disk.os_type.name = 'Param 5'
         instance.storage_profile.os_disk.managed_disk.storage_account_type = StorageAccountTypes.premium_lrs
 
-        instance.network_interfaces = []
+        instance.network_profile = Mock()
+        instance.network_profile.network_interfaces = MagicMock()
 
         vm_instance_data = self.vm_details_provider.create(instance, True, self.logger, self.network_client,
                                                            '').vm_instance_data
@@ -40,7 +41,8 @@ class TestVmDetailsProvider(TestCase):
 
     def test_prepare_vm_details_from_image(self):
         instance = Mock()
-        instance.network_interfaces = []
+        instance.network_profile = Mock()
+        instance.network_profile.network_interfaces = MagicMock()
         resource_group = 'Group 1'
         self.resource_id_parser.get_image_name = Mock(return_value='Image Name')
         self.resource_id_parser.get_resource_group_name = Mock(return_value=resource_group)
@@ -58,7 +60,7 @@ class TestVmDetailsProvider(TestCase):
             self._get_value(vm_instance_data, 'Operating System') == instance.storage_profile.os_disk.os_type.name)
         self.assertTrue(self._get_value(vm_instance_data, 'Disk Type') == 'SSD')
 
-    def test_prepare_vm_network_data(self):
+    def test_prepare_vm_network_data_single_nic(self):
         network_interface = Mock()
         network_interface.resource_guid = 'Param Guid'
         network_interface.name = 'Param Name'
@@ -72,10 +74,11 @@ class TestVmDetailsProvider(TestCase):
 
         self.network_client.network_interfaces.get = Mock(return_value=network_interface)
 
+        nic = Mock()
+        nic.id = "/azure_resource_id/nic_name"
         instance = Mock()
-        instance.network_interfaces = [
-            network_interface
-        ]
+        instance.network_profile = Mock()
+        instance.network_profile.network_interfaces = [nic]
 
         public_ip = Mock()
         public_ip.ip_address = 'Public Address Param'


### PR DESCRIPTION
1. added support for multiple subnets in GetVmDetails
2. fixed RefreshIP operation to always get the IP from the primary nic

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/azure-shell/510)
<!-- Reviewable:end -->
