### PR TITLE
added allow all sandbox traffic to custom image

### DIFF
--- a/drivers/azure_shellPackage/DataModel/datamodel.xml
+++ b/drivers/azure_shellPackage/DataModel/datamodel.xml
@@ -378,6 +378,9 @@
                 <AllowedValue>SSD</AllowedValue>
               </AllowedValues>
             </AttachedAttribute>
+            <AttachedAttribute IsLocal="true" IsOverridable="true" Name="Allow all Sandbox Traffic" UserInput="true">
+              <AllowedValues />
+            </AttachedAttribute>
           </AttachedAttributes>
           <AttributeValues>
             <AttributeValue Name="Public IP Type" Value="Dynamic" />


### PR DESCRIPTION
Bug 169012:"AllowAllTrafic" does not appear under Azure Image app

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/azure-shell/548)
<!-- Reviewable:end -->
